### PR TITLE
add simplified Chinese (PRC) translation for all language variants.

### DIFF
--- a/language/zh-cn.json
+++ b/language/zh-cn.json
@@ -1,0 +1,19 @@
+{
+  "libraryStrings": {
+    "l10n.back": "返回",
+    "l10n.noBackgroundImage": "背景图像缺失",
+    "l10n.noBackgroundImageMessage": "在向地图添加关卡之前，您必须先选择背景图像。",
+    "l10n.toolbarButton-stage": "关卡",
+    "l10n.done": "完成",
+    "l10n.remove": "移除",
+    "l10n.selectAll": "全选",
+    "l10n.deselectAll": "取消全选",
+    "l10n.noNeighbors": "您还没有创建可连接的关卡。",
+    "l10n.contentRequired": "您需要为此关卡选择一个内容类型。",
+    "l10n.unnamedStage": "未命名关卡",
+    "l10n.confirmationDialogRemoveHeader": "删除关卡",
+    "l10n.confirmationDialogRemoveDialog": "确定要删除此关卡？",
+    "l10n.confirmationDialogRemoveCancel": "取消",
+    "l10n.confirmationDialogRemoveConfirm": "是的"
+  }
+}

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -1,0 +1,19 @@
+{
+  "libraryStrings": {
+    "l10n.back": "返回",
+    "l10n.noBackgroundImage": "背景图像缺失",
+    "l10n.noBackgroundImageMessage": "在向地图添加关卡之前，您必须先选择背景图像。",
+    "l10n.toolbarButton-stage": "关卡",
+    "l10n.done": "完成",
+    "l10n.remove": "移除",
+    "l10n.selectAll": "全选",
+    "l10n.deselectAll": "取消全选",
+    "l10n.noNeighbors": "您还没有创建可连接的关卡。",
+    "l10n.contentRequired": "您需要为此关卡选择一个内容类型。",
+    "l10n.unnamedStage": "未命名关卡",
+    "l10n.confirmationDialogRemoveHeader": "删除关卡",
+    "l10n.confirmationDialogRemoveDialog": "确定要删除此关卡？",
+    "l10n.confirmationDialogRemoveCancel": "取消",
+    "l10n.confirmationDialogRemoveConfirm": "是的"
+  }
+}

--- a/language/zh.json
+++ b/language/zh.json
@@ -1,0 +1,19 @@
+{
+  "libraryStrings": {
+    "l10n.back": "返回",
+    "l10n.noBackgroundImage": "背景图像缺失",
+    "l10n.noBackgroundImageMessage": "在向地图添加关卡之前，您必须先选择背景图像。",
+    "l10n.toolbarButton-stage": "关卡",
+    "l10n.done": "完成",
+    "l10n.remove": "移除",
+    "l10n.selectAll": "全选",
+    "l10n.deselectAll": "取消全选",
+    "l10n.noNeighbors": "您还没有创建可连接的关卡。",
+    "l10n.contentRequired": "您需要为此关卡选择一个内容类型。",
+    "l10n.unnamedStage": "未命名关卡",
+    "l10n.confirmationDialogRemoveHeader": "删除关卡",
+    "l10n.confirmationDialogRemoveDialog": "确定要删除此关卡？",
+    "l10n.confirmationDialogRemoveCancel": "取消",
+    "l10n.confirmationDialogRemoveConfirm": "是的"
+  }
+}


### PR DESCRIPTION
Hi @otacke 

Thanks again for this excellent content type as always.

I am submitting a pull request to add Simplified Chinese (PRC) translations for all the variants. This will enable users who prefer Simplified Chinese (PRC) to use this language option across all the simplified Chinese variants code, i.e. zh, zh-cn, and zh-hans.

Thank you for considering my contribution. Please let me know if there are any changes or modifications that need to be made to this pull request.

Best regards,
Sam